### PR TITLE
Fixing the problem not to handle binary data (jpg/png/etc) correctly …

### DIFF
--- a/webiopi-pi2bplus.patch
+++ b/webiopi-pi2bplus.patch
@@ -135,7 +135,17 @@ diff -ur WebIOPi-0.7.1/python/webiopi/utils/version.py WebIOPi-Pi2/python/webiop
  
 --- WebIOPi-0.7.1/python/webiopi/protocols/http.py	2014-02-22 07:31:18.000000000 +0900
 +++ WebIOPi-Pi2/python/webiopi/protocols/http.py	2017-08-18 16:53:56.000000000 +0900
-@@ -198,9 +198,19 @@
+@@ -194,13 +194,23 @@
+         
+         (contentType, encoding) = mime.guess_type(path)
+         f = codecs.open(path, encoding=encoding)
+-        data = f.read()
++        try:
++            data = f.read()
++        except UnicodeDecodeError:
++            f.close()
++            f = codecs.open(path, mode='rb', encoding=encoding)
++            data = f.read()
          f.close()
          self.send_response(200)
          self.send_header("Content-Type", contentType);
@@ -143,15 +153,10 @@ diff -ur WebIOPi-0.7.1/python/webiopi/utils/version.py WebIOPi-Pi2/python/webiop
 -        self.end_headers()
 -        self.wfile.write(data)
 +        try:
-+            data.encode()
-+            dataEncode = True
-+        except AttributeError:
-+            dataEncode = False
-+        if dataEncode == True:
 +            self.send_header("Content-Length", len(data.encode()))
 +            self.end_headers()
 +            self.wfile.write(data.encode())
-+        else:
++        except AttributeError:
 +            self.send_header("Content-Length", os.path.getsize(realPath))
 +            self.end_headers()
 +            self.wfile.write(data)


### PR DESCRIPTION
On the previous version, I noticed that WebIOPi with Python 3.5 on Raspbian Stretch 
cannot process binary data such as jpg, png, etc 
although it can process text data such as html, js, css, etc.

Therefore, I changed the codes as follows.

Of course this version works with  Python 3.4 on Raspbian Jessie.

(old)
```
f = codecs.open(path, encoding=encoding)
data = f.read()
```
(new)
```
f = codecs.open(path, encoding=encoding)
try:
    data = f.read()    # For text data (html, js, css, etc)
except UnicodeDecodeError:
    f.close()
    f = codecs.open(path, mode='rb', encoding=encoding) # For binary data (jpg, png, etc)
    data = f.read()
```