### PR TITLE
Fix for kernel 5.x on Pi 4

### DIFF
--- a/webiopi-pi2bplus.patch
+++ b/webiopi-pi2bplus.patch
@@ -22,13 +22,15 @@ diff -ur WebIOPi-0.7.1/htdocs/webiopi.js WebIOPi-Pi2/htdocs/webiopi.js
 diff -ur WebIOPi-0.7.1/python/native/cpuinfo.c WebIOPi-Pi2/python/native/cpuinfo.c
 --- WebIOPi-0.7.1/python/native/cpuinfo.c	2012-10-29 06:26:10.000000000 +0900
 +++ WebIOPi-Pi2/python/native/cpuinfo.c	2015-06-26 16:10:24.893330537 +0900
-@@ -39,6 +39,10 @@
+@@ -39,6 +39,12 @@
        sscanf(buffer, "Hardware	: %s", hardware);
        if (strcmp(hardware, "BCM2708") == 0)
           rpi_found = 1;
 +      else if (strcmp(hardware, "BCM2709") == 0)
 +         rpi_found = 1;
 +      else if (strcmp(hardware, "BCM2835") == 0)
++         rpi_found = 1;
++      else if (strcmp(hardware, "BCM2711") == 0)
 +         rpi_found = 1;
        sscanf(buffer, "Revision	: %s", revision);
     }


### PR DESCRIPTION
Kernel 5.x on Pi 4 returns "Hardware: BCM2711"  for "cat /proc/cpuinfo" while kernel 4.x returns "Hardware: BCM2835".
I fixed this problem.