### PR TITLE
add: BCM271(used for Raspberry Pi 4B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,12 @@ WebIOPi-0.7.1 Patch for Raspberry B+, Pi2, Pi3, and Pi4
 
 You have full access to all header pins (40 pins) on the Web interface.
 
-既存のパッチに加えてBCM2711を搭載しているモデルでの問題を修正しています．
-(Fixed a issue that prevented BCM2711 models (Raspberry Pi 4B) from passing the startup check.)
-
 ## Usage
 ------
 $ wget http://sourceforge.net/projects/webiopi/files/WebIOPi-0.7.1.tar.gz  
 $ tar xvzf WebIOPi-0.7.1.tar.gz  
 $ cd WebIOPi-0.7.1  
-$ wget https://raw.githubusercontent.com/UshiTaro/WebIOPi-for-Raspberry-Pi-4B/master/webiopi-pi2bplus.patch
+$ wget https://raw.githubusercontent.com/doublebind/raspi/master/webiopi-pi2bplus.patch  
 $ patch -p1 -i webiopi-pi2bplus.patch  
 $ sudo ./setup.sh
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,15 @@ WebIOPi-0.7.1 Patch for Raspberry B+, Pi2, Pi3, and Pi4
 
 You have full access to all header pins (40 pins) on the Web interface.
 
+既存のパッチに加えてBCM2711を搭載しているモデルでの問題を修正しています．
+(Fixed a issue that prevented BCM2711 models (Raspberry Pi 4B) from passing the startup check.)
+
 ## Usage
 ------
 $ wget http://sourceforge.net/projects/webiopi/files/WebIOPi-0.7.1.tar.gz  
 $ tar xvzf WebIOPi-0.7.1.tar.gz  
 $ cd WebIOPi-0.7.1  
-$ wget https://raw.githubusercontent.com/doublebind/raspi/master/webiopi-pi2bplus.patch  
+$ wget https://raw.githubusercontent.com/UshiTaro/WebIOPi-for-Raspberry-Pi-4B/master/webiopi-pi2bplus.patch
 $ patch -p1 -i webiopi-pi2bplus.patch  
 $ sudo ./setup.sh
 

--- a/webiopi-pi2bplus.patch
+++ b/webiopi-pi2bplus.patch
@@ -22,13 +22,15 @@ diff -ur WebIOPi-0.7.1/htdocs/webiopi.js WebIOPi-Pi2/htdocs/webiopi.js
 diff -ur WebIOPi-0.7.1/python/native/cpuinfo.c WebIOPi-Pi2/python/native/cpuinfo.c
 --- WebIOPi-0.7.1/python/native/cpuinfo.c	2012-10-29 06:26:10.000000000 +0900
 +++ WebIOPi-Pi2/python/native/cpuinfo.c	2015-06-26 16:10:24.893330537 +0900
-@@ -39,6 +39,10 @@
+@@ -39,6 +39,12 @@
        sscanf(buffer, "Hardware	: %s", hardware);
        if (strcmp(hardware, "BCM2708") == 0)
           rpi_found = 1;
 +      else if (strcmp(hardware, "BCM2709") == 0)
 +         rpi_found = 1;
 +      else if (strcmp(hardware, "BCM2835") == 0)
++         rpi_found = 1;
++      else if (strcmp(hardware, "BCM2711") == 0)
 +         rpi_found = 1;
        sscanf(buffer, "Revision	: %s", revision);
     }


### PR DESCRIPTION
Fixed a problem that BCM2711 installed model (Raspberry Pi 4B) does not start normally.